### PR TITLE
Add comments explaining non-obvious logic

### DIFF
--- a/kube-selector.py
+++ b/kube-selector.py
@@ -17,6 +17,7 @@ CURRENT = None
 try:
     CURRENT = os.readlink(DST)
 except OSError as error:
+    # Abort if config exists but is a plain file — switching would silently overwrite it.
     if error.errno == errno.EINVAL:
         print(
             "[ERROR] Current config file is not a symlink. Aborting to avoid current config loss.")
@@ -30,6 +31,7 @@ for conffile in os.listdir(CONF_PATH):
 
 conffiles.sort()
 
+# Bubble the active config to the top so fzf pre-selects it.
 for conffile in list(conffiles):
     if os.path.join(CONF_PATH, conffile) == CURRENT:
         conffiles.remove(conffile)
@@ -46,6 +48,7 @@ except KeyboardInterrupt:
     sys.exit(0)
 
 src = os.path.join(CONF_PATH, val)
+# Write to a temp path then rename for an atomic swap — avoids a window where DST is missing.
 tmp = tempfile.mktemp(dir=CONF_PATH)
 os.symlink(src, tmp)
 os.replace(tmp, DST)


### PR DESCRIPTION
## Summary
- Explain why a plain-file config triggers a hard abort (silent overwrite risk)
- Explain why the active config is bubbled to the top of the list (fzf pre-selection)
- Explain the temp-file-then-rename pattern (atomic symlink swap)

## Test plan
- [ ] Run `pylint kube-selector.py` and confirm score remains 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)